### PR TITLE
update URL encoding to support Unicode char selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 function encodeForCyberChef(data) {
-  return btoa(unescape(encodeURIComponent(data)));
+  return encodeURIComponent(btoa(unescape(encodeURIComponent(data))));
 }
 
 openInCyberChef = function(word){

--- a/main.js
+++ b/main.js
@@ -1,10 +1,14 @@
+function encodeForCyberChef(data) {
+  return btoa(unescape(encodeURIComponent(data)));
+}
+
 openInCyberChef = function(word){
   var query = word.selectionText;
   browser.storage.local.get("my_url", function(items) {
 	if (!!items.my_url) {
-		browser.tabs.create({url: items.my_url + "#input=" + encodeURIComponent(btoa(query))});
+		browser.tabs.create({url: items.my_url + "#input=" + encodeForCyberChef(query)});
 	} else {
-		browser.tabs.create({url: "https://gchq.github.io/CyberChef#input=" + encodeURIComponent(btoa(query))});
+		browser.tabs.create({url: "https://gchq.github.io/CyberChef#input=" + encodeForCyberChef(query)});
 	}
   });
 };


### PR DESCRIPTION
fixes #3 
https://developer.mozilla.org/en-US/docs/Glossary/Base64#solution_1_%E2%80%93_escaping_the_string_before_encoding_it

Correctly encode strings that contain Unicode. Existing ascii strings are encoded the same

Moves the reused encoding routine to its own function

**Explanation:**
 - `btoa(unescape(encodeURIComponent(data)))` runs btoa on the converted form that accounts for non-ascii characters.
 - final encodeURIcomponent() sends the base64 string to cyberchef url with correct url escapes