### PR TITLE
Firefox extension - mv3 release version

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-  <script src="main.js"></script>
-</body>
-</html>

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ openInCyberChef = function(word){
 };
 
 browser.contextMenus.create({
-  title: "Open in CyberChef (mv3)",
+  title: "Open in CyberChef",
   id: "open-in-cyberchef",
   contexts:["selection"]
 });

--- a/main.js
+++ b/main.js
@@ -3,18 +3,21 @@ function encodeForCyberChef(data) {
 }
 
 openInCyberChef = function(word){
-  var query = word.selectionText;
   browser.storage.local.get("my_url", function(items) {
 	if (!!items.my_url) {
-		browser.tabs.create({url: items.my_url + "#input=" + encodeForCyberChef(query)});
+		browser.tabs.create({url: items.my_url + "#input=" + encodeForCyberChef(word)});
 	} else {
-		browser.tabs.create({url: "https://gchq.github.io/CyberChef#input=" + encodeForCyberChef(query)});
+		browser.tabs.create({url: "https://gchq.github.io/CyberChef#input=" + encodeForCyberChef(word)});
 	}
   });
 };
 
 browser.contextMenus.create({
-  title: "Open in CyberChef",
-  contexts:["selection"],
-  onclick: openInCyberChef
+  title: "Open in CyberChef (mv3)",
+  id: "open-in-cyberchef",
+  contexts:["selection"]
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+    openInCyberChef(info.selectionText);
 });

--- a/main.js
+++ b/main.js
@@ -12,10 +12,12 @@ openInCyberChef = function(word){
   });
 };
 
-browser.contextMenus.create({
-  title: "Open in CyberChef",
-  id: "open-in-cyberchef",
-  contexts:["selection"]
+chrome.runtime.onInstalled.addListener(() => {
+  browser.contextMenus.create({
+    title: "Open in CyberChef",
+    id: "open-in-cyberchef",
+    contexts:["selection"]
+  });
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {

--- a/main.js
+++ b/main.js
@@ -12,12 +12,10 @@ openInCyberChef = function(word){
   });
 };
 
-chrome.runtime.onInstalled.addListener(() => {
-  browser.contextMenus.create({
-    title: "Open in CyberChef",
-    id: "open-in-cyberchef",
-    contexts:["selection"]
-  });
+browser.contextMenus.create({
+  title: "Open in CyberChef",
+  id: "open-in-cyberchef",
+  contexts:["selection"]
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,23 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Open in CyberChef",
   "short_name": "CyberChef",
   "description": "Adds an open selected text in CyberChef option to the right-click context menu. CyberChef is a tool that can decode, decipher, and uncompress data in a wide variety of formats.",
-  "version": "0.0.4",
+  "version": "0.3.0",
   "permissions": [
     "storage",
     "contextMenus", 
     "tabs"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{18e2eddf-0137-4dcc-bbd4-abf906665bd8}"
+    }
+  },
   "icons": {
     "16": "assets/cyberchef-16x16.png",
     "48": "assets/cyberchef-48x48.png",
     "128": "assets/cyberchef-128x128.png"
   },
   "options_ui": {"page": "options.html" },
-  "background": {"page": "background.html"}
+  "background": {"scripts": ["main.js"]}
 }


### PR DESCRIPTION
This PR creates a new version of the extension with the firefox mv3 api, which is now released in the latest Firefox 109 stable release.
I tested this version and it works

The following changes were made to support mv3:
 - added extension id (this is [required for mv3 extensions](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/))
 - added an `id` property to the context menu, which is required for the menu to work in mv3
 - replaced the `onclick` property with `chrome.contextMenus.onClicked.addListener((info, tab))`, which is required for mv3 context menu click actions.

- bump version to 0.3.0

this version will be automatically offered to firefox versions 109 and up. 
the functionality is the same, and older versions of firefox will continue to use the mv2 0.0.4 release.